### PR TITLE
Change the CI pipeline to only save flake results when error.

### DIFF
--- a/azure-pipelines-pr-gate.yml
+++ b/azure-pipelines-pr-gate.yml
@@ -54,9 +54,14 @@ steps:
     reportDirectory: $(System.DefaultWorkingDirectory)/cov_html
   condition: succeededOrFailed()
 
-- script: flake8 . > flake8.err.log
+- script: flake8 .
   displayName: 'Run flake8'
   condition: succeededOrFailed()
+
+# Only capture and archive the lint log on failures.
+- script: flake8 . > flake8.err.log
+  displayName: 'Capture flake8 failures'
+  condition: Failed()
 
 - task: PublishBuildArtifacts@1
   inputs:

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -56,9 +56,14 @@ steps:
     reportDirectory: $(System.DefaultWorkingDirectory)/cov_html
   condition: succeededOrFailed()
 
-- script: flake8 . > flake8.err.log
+- script: flake8 .
   displayName: 'Run flake8'
   condition: succeededOrFailed()
+
+# Only capture and archive the lint log on failures.
+- script: flake8 . > flake8.err.log
+  displayName: 'Capture flake8 failures'
+  condition: Failed()
 
 - task: PublishBuildArtifacts@1
   inputs:


### PR DESCRIPTION
This allows the output to be printed to screen, for easier access.